### PR TITLE
Reject messages without encrypted flag

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -348,6 +348,9 @@ func (me *TestHelper) CreatePostWithClient(client *model.Client4, channel *model
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   "message_" + id,
+		Props: model.StringInterface{
+			"encrypted": true,
+		},
 	}
 
 	utils.DisableDebugLogForTest()
@@ -366,6 +369,9 @@ func (me *TestHelper) CreatePinnedPostWithClient(client *model.Client4, channel 
 		ChannelId: channel.Id,
 		Message:   "message_" + id,
 		IsPinned:  true,
+		Props: model.StringInterface{
+			"encrypted": true,
+		},
 	}
 
 	utils.DisableDebugLogForTest()
@@ -381,6 +387,9 @@ func (me *TestHelper) CreateMessagePostWithClient(client *model.Client4, channel
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   message,
+		Props: model.StringInterface{
+			"encrypted": true,
+		},
 	}
 
 	utils.DisableDebugLogForTest()
@@ -398,6 +407,9 @@ func (me *TestHelper) CreateMessagePostNoClient(channel *model.Channel, message 
 		ChannelId: channel.Id,
 		Message:   message,
 		CreateAt:  createAtTime,
+		Props: model.StringInterface{
+			"encrypted": true,
+		},
 	})).(*model.Post)
 
 	return post

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -909,7 +909,13 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal("should have failed to get deleted channel")
 	}
 
-	post1 := &model.Post{ChannelId: publicChannel1.Id, Message: "a" + GenerateTestId() + "a"}
+	post1 := &model.Post{
+		ChannelId: publicChannel1.Id,
+		Message:   "a" + GenerateTestId() + "a",
+		Props: model.StringInterface{
+			"encrypted": true,
+		},
+	}
 	if _, err := Client.CreatePost(post1); err == nil {
 		t.Fatal("should have failed to post to deleted channel")
 	}
@@ -1890,7 +1896,13 @@ func TestAddChannelMember(t *testing.T) {
 		t.Fatal("should have returned exact user added to private channel")
 	}
 
-	post := &model.Post{ChannelId: publicChannel.Id, Message: "a" + GenerateTestId() + "a"}
+	post := &model.Post{
+		ChannelId: publicChannel.Id,
+		Message:   "a" + GenerateTestId() + "a",
+		Props: model.StringInterface{
+			"encrypted": true,
+		},
+	}
 	rpost, err := Client.CreatePost(post)
 	if err == nil {
 		t.Fatal("should have created a post")

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -265,6 +265,9 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 		ChannelId: channel.Id,
 		Message:   "message_" + id,
 		CreateAt:  model.GetMillis() - 10000,
+		Props: model.StringInterface{
+			"encrypted": true,
+		},
 	}
 
 	utils.DisableDebugLogForTest()

--- a/app/post.go
+++ b/app/post.go
@@ -142,6 +142,16 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 		return foundPost, nil
 	}
 
+	if value, ok := post.Props["encrypted"]; ok {
+		if isEncrypted, isBool := value.(bool); isBool && !isEncrypted {
+			err := model.NewAppError("createPost", "api.post.create_post.message_not_encrypted.error", nil, "", http.StatusBadRequest)
+			return nil, err
+		}
+	} else {
+		err := model.NewAppError("createPost", "api.post.create_post.message_not_encrypted.error", nil, "", http.StatusBadRequest)
+		return nil, err
+	}
+
 	// If we get this far, we've recorded the client-provided pending post id to the cache.
 	// Remove it if we fail below, allowing a proper retry by the client.
 	defer func() {


### PR DESCRIPTION
#### Summary
Reject messages that do not carry an encrypted props flag.